### PR TITLE
Rename PC_PatchTransform to PC_SetPCID

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 **PC_SetPCID(p pcpatch, pcid int4)** returns **pcpatch**
 
-> Set the schema on a PcPatch, given a valid `pcid` schema number. The values of dimensions may change if offsets or scales in the "new" schema are not the same as in the "old" schema. Also, 0 values will be used for dimensions that are in the new schema but not in the old schema. And the values of dimensions that are in the old schema but not in the new schema will be lost.
+> Sets the schema on a PcPatch, given a valid `pcid` schema number. The internal values of the points may change for dimensions where the offset and/or scale are different between the "old" and the "new" schema, so that the corresponding double values are unchanged, up to the precision of the underlying representation. Also, 0 values will be used for dimensions that are in the new schema but not in the old schema. And the values of dimensions that are in the old schema but not in the new schema will be discarded.
 
 ## PostGIS Integration ##
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,10 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 > Returns a patch containing *n* points. These points are selected from the *start*-th point of the patch in parameter.
 
+**PC_SetPCID(p pcpatch, pcid int4)** returns **pcpatch**
+
+> Set the schema on a PcPatch, given a valid `pcid` schema number. The values of dimensions may change if offsets or scales in the "new" schema are not the same as in the "old" schema. Also, 0 values will be used for dimensions that are in the new schema but not in the old schema. And the values of dimensions that are in the old schema but not in the new schema will be lost.
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -771,7 +771,7 @@ test_patch_range_compression_none()
 }
 
 static void
-test_patch_transform_compression_none()
+test_patch_set_schema_compression_none()
 {
     // init data
     PCPATCH_UNCOMPRESSED *pau;
@@ -797,8 +797,8 @@ test_patch_transform_compression_none()
 
     pau = pc_patch_uncompressed_from_pointlist(pl);
 
-    // transform a patch to a valid schema
-    pat = pc_patch_transform((PCPATCH*) pau, simplexyzschema);
+    // assign a valid schema to the patch
+    pat = pc_patch_set_schema((PCPATCH*) pau, simplexyzschema);
     str = pc_patch_to_string(pat);
 
     CU_ASSERT(pat != NULL);
@@ -847,7 +847,7 @@ test_patch_range_compression_lazperf()
 }
 
 static void
-test_patch_transform_compression_lazperf()
+test_patch_set_schema_compression_lazperf()
 {
     // init data
     PCPATCH_LAZPERF *pal;
@@ -873,8 +873,8 @@ test_patch_transform_compression_lazperf()
 
     pal = pc_patch_lazperf_from_pointlist(pl);
 
-    // transform a patch to a valid schema
-    pat = pc_patch_transform((PCPATCH*) pal, simplexyzschema);
+    // assign a valid schema to the patch
+    pat = pc_patch_set_schema((PCPATCH*) pal, simplexyzschema);
     str = pc_patch_to_string(pat);
 
     CU_ASSERT(pat != NULL);
@@ -938,7 +938,7 @@ test_patch_range_compression_dimensional(enum DIMCOMPRESSIONS dimcomp)
 }
 
 static void
-test_patch_transform_compression_ght()
+test_patch_set_schema_compression_ght()
 {
     // init data
     PCPATCH_GHT *pag;
@@ -965,8 +965,8 @@ test_patch_transform_compression_ght()
 #ifdef HAVE_LIBGHT
     pag = pc_patch_ght_from_pointlist(pl);
 
-    // transform a patch to a valid schema
-    pat0 = pc_patch_transform((PCPATCH*) pag, simplexyzschema);
+    // assign a valid schema to the patch
+    pat0 = pc_patch_set_schema((PCPATCH*) pag, simplexyzschema);
     str = pc_patch_to_string(pat0);
 
     CU_ASSERT(pat0 != NULL);
@@ -974,8 +974,8 @@ test_patch_transform_compression_ght()
 
     pcfree(str);
 
-    // transform a patch to a schema with unkown dimension
-    pat1 = pc_patch_transform(pat0, simpleschema);
+    // assign a schema with unknown dimension to the patch
+    pat1 = pc_patch_set_schema(pat0, simpleschema);
     str = pc_patch_to_string(pat1);
 
     CU_ASSERT(pat1 != NULL);
@@ -985,8 +985,6 @@ test_patch_transform_compression_ght()
     pc_patch_free(pat1);
     pcfree(str);
 
-    /*CU_ASSERT_STRING_EQUAL(str, "{\"pcid\":0,\"pts\":[[0,0,0,10],[0.1,0.2,0.3,10],[0.2,0.4,0.6,10],[0.3,0.6,0.9,10],[0.4,0.8,1.2,10]]}");*/
-
     pc_patch_free((PCPATCH*) pag);
 #endif
 
@@ -994,7 +992,7 @@ test_patch_transform_compression_ght()
 }
 
 static void
-test_patch_transform_dimensional_compression(enum DIMCOMPRESSIONS dimcomp)
+test_patch_set_schema_dimensional_compression(enum DIMCOMPRESSIONS dimcomp)
 {
     // init data
     PCPATCH_DIMENSIONAL *padim1, *padim2;
@@ -1029,8 +1027,8 @@ test_patch_transform_dimensional_compression(enum DIMCOMPRESSIONS dimcomp)
     // compress patch
     padim2 = pc_patch_dimensional_compress(padim1, stats);
 
-    // transform a patch to a valid schema
-    pat = pc_patch_transform((PCPATCH*) padim2, simplexyzschema);
+    // assign a valid schema to the patch
+    pat = pc_patch_set_schema((PCPATCH*) padim2, simplexyzschema);
 
     pt = pc_patch_pointn(pat, 1);
     str = pc_point_to_string(pt);
@@ -1073,27 +1071,27 @@ test_patch_range_compression_dimensional_rle()
 }
 
 static void
-test_patch_transform_dimensional_compression_none()
+test_patch_set_schema_dimensional_compression_none()
 {
-    test_patch_transform_dimensional_compression(PC_DIM_NONE);
+    test_patch_set_schema_dimensional_compression(PC_DIM_NONE);
 }
 
 static void
-test_patch_transform_dimensional_compression_zlib()
+test_patch_set_schema_dimensional_compression_zlib()
 {
-    test_patch_transform_dimensional_compression(PC_DIM_ZLIB);
+    test_patch_set_schema_dimensional_compression(PC_DIM_ZLIB);
 }
 
 static void
-test_patch_transform_dimensional_compression_sigbits()
+test_patch_set_schema_dimensional_compression_sigbits()
 {
-    test_patch_transform_dimensional_compression(PC_DIM_SIGBITS);
+    test_patch_set_schema_dimensional_compression(PC_DIM_SIGBITS);
 }
 
 static void
-test_patch_transform_dimensional_compression_rle()
+test_patch_set_schema_dimensional_compression_rle()
 {
-    test_patch_transform_dimensional_compression(PC_DIM_RLE);
+    test_patch_set_schema_dimensional_compression(PC_DIM_RLE);
 }
 
 /* REGISTER ***********************************************************/
@@ -1124,14 +1122,14 @@ CU_TestInfo patch_tests[] = {
 #ifdef HAVE_LAZPERF
 	PC_TEST(test_patch_range_compression_lazperf),
 #endif
-	PC_TEST(test_patch_transform_compression_none),
-	PC_TEST(test_patch_transform_compression_ght),
-	PC_TEST(test_patch_transform_dimensional_compression_none),
-	PC_TEST(test_patch_transform_dimensional_compression_zlib),
-	PC_TEST(test_patch_transform_dimensional_compression_sigbits),
-	PC_TEST(test_patch_transform_dimensional_compression_rle),
+	PC_TEST(test_patch_set_schema_compression_none),
+	PC_TEST(test_patch_set_schema_compression_ght),
+	PC_TEST(test_patch_set_schema_dimensional_compression_none),
+	PC_TEST(test_patch_set_schema_dimensional_compression_zlib),
+	PC_TEST(test_patch_set_schema_dimensional_compression_sigbits),
+	PC_TEST(test_patch_set_schema_dimensional_compression_rle),
 #ifdef HAVE_LAZPERF
-	PC_TEST(test_patch_transform_compression_lazperf),
+	PC_TEST(test_patch_set_schema_compression_lazperf),
 #endif
 	CU_TEST_INFO_NULL
 };

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -443,7 +443,7 @@ PCPATCH *pc_patch_interp(
 /** Subset batch based on index */
 PCPATCH* pc_patch_range(const PCPATCH *pa, int first, int cound);
 
-/** transform a patch with a different schema*/
-PCPATCH *pc_patch_transform(const PCPATCH *patch, const PCSCHEMA *schema);
+/** assign a schema to the patch */
+PCPATCH *pc_patch_set_schema(const PCPATCH *patch, const PCSCHEMA *schema);
 
 #endif /* _PC_API_H */

--- a/lib/pc_patch.c
+++ b/lib/pc_patch.c
@@ -613,8 +613,9 @@ PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n)
     return NULL;
 }
 
+/** set schema for patch */
 PCPATCH*
-pc_patch_transform(const PCPATCH *patch, const PCSCHEMA *new_schema)
+pc_patch_set_schema(const PCPATCH *patch, const PCSCHEMA *new_schema)
 {
     PCPATCH_UNCOMPRESSED *paout = NULL;
     PCPOINTLIST *opl, *npl;

--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -25,7 +25,7 @@ Datum pcpatch_compress(PG_FUNCTION_ARGS);
 Datum pcpatch_numpoints(PG_FUNCTION_ARGS);
 Datum pcpatch_pointn(PG_FUNCTION_ARGS);
 Datum pcpatch_range(PG_FUNCTION_ARGS);
-Datum pcpatch_transform(PG_FUNCTION_ARGS);
+Datum pcpatch_setpcid(PG_FUNCTION_ARGS);
 Datum pcpatch_pcid(PG_FUNCTION_ARGS);
 Datum pcpatch_summary(PG_FUNCTION_ARGS);
 Datum pcpatch_compression(PG_FUNCTION_ARGS);
@@ -693,8 +693,8 @@ Datum pcpatch_range(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(serpaout);
 }
 
-PG_FUNCTION_INFO_V1(pcpatch_transform);
-Datum pcpatch_transform(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(pcpatch_setpcid);
+Datum pcpatch_setpcid(PG_FUNCTION_ARGS)
 {
 	PCPATCH *paout = NULL;
 	SERIALIZED_PATCH *serpatch;
@@ -705,7 +705,7 @@ Datum pcpatch_transform(PG_FUNCTION_ARGS)
 	PCPATCH *patch = pc_patch_deserialize(serpa, schema);
 
 	if(patch) {
-	  paout = pc_patch_transform(patch, new_schema);
+	  paout = pc_patch_set_schema(patch, new_schema);
 	  pc_patch_free(patch);
 	}
 

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -314,8 +314,8 @@ CREATE OR REPLACE FUNCTION PC_Range(p pcpatch, first int4, count int4)
     RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_range'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION PC_PatchTransform(p pcpatch, pcid int4)
-    RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_transform'
+CREATE OR REPLACE FUNCTION PC_SetPCID(p pcpatch, pcid int4)
+    RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_setpcid'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
 -------------------------------------------------------------------


### PR DESCRIPTION
`PC_PatchTransform` sets a new schema in a patch, based on a pcid. So this function doesn't actually transform the patch data, it just sets a new schema for the patch. Based on that this PR renames the function to `PC_SetPCID`.

User code impacted by this change:

- [x] [LI3DS/lopocs](https://github.com/LI3DS/lopocs/search?utf8=%E2%9C%93&q=PC_PatchTransform)