### PR TITLE
Fix unit tests with cunit 2.1-3

### DIFF
--- a/lib/cunit/cu_pc_interp.c
+++ b/lib/cunit/cu_pc_interp.c
@@ -150,4 +150,9 @@ CU_TestInfo interp_tests[] = {
     CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo interp_suite = {"interp", init_suite, clean_suite, interp_tests};
+CU_SuiteInfo interp_suite = {
+    .pName = "interp",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = interp_tests
+};


### PR DESCRIPTION
This follows up on commit 7cda0a1 and fixes the cu_pc_interp unit tests for cunit 2.1-3.