### PR TITLE
Fix typing in pc_interp.c

### DIFF
--- a/lib/pc_interp.c
+++ b/lib/pc_interp.c
@@ -50,7 +50,7 @@ void * blower_arg(
             lim++;
         } 		/* else move left */
     }
-    return base;
+    return ((void *)base);
 }
 
 
@@ -139,7 +139,7 @@ pc_point_uncompressed_interp(const PCPATCH_UNCOMPRESSED *pu, PCDIMENSION *dim, d
     return NULL;
 }
 
-static PCPATCH *
+static PCPATCH_UNCOMPRESSED *
 pc_patch_uncompressed_interp(const PCPATCH_UNCOMPRESSED *pu1, const PCPATCH_UNCOMPRESSED *pu2, 
     PCDIMENSION *dim1, PCDIMENSION *dim2, char sorted1, char sorted2)
 {
@@ -171,9 +171,9 @@ pc_patch_uncompressed_interp(const PCPATCH_UNCOMPRESSED *pu1, const PCPATCH_UNCO
         buf2 += sz2;
     }
     
-    if(pa->npoints) return (PCPATCH *)pa;
+    if(pa->npoints) return pa;
     
-    pc_patch_free(pa);
+    pc_patch_free((PCPATCH *)pa);
     return NULL;    
 }
 
@@ -224,7 +224,7 @@ PCPATCH *pc_patch_interp(
         pcerror("Patch uncompression failed");
         return NULL;
     }
-    PCPATCH *pa = pc_patch_uncompressed_interp((PCPATCH_UNCOMPRESSED *)pu1,(PCPATCH_UNCOMPRESSED *)pu2,dim1,dim2,sorted1,sorted2);
+    PCPATCH_UNCOMPRESSED *pa = pc_patch_uncompressed_interp((PCPATCH_UNCOMPRESSED *)pu1,(PCPATCH_UNCOMPRESSED *)pu2,dim1,dim2,sorted1,sorted2);
     if ( pu1 != p1 )
         pc_patch_free(pu1);
     if ( pu2 != p2 )
@@ -232,17 +232,17 @@ PCPATCH *pc_patch_interp(
 
 	if ( pa && PC_FAILURE == pc_patch_uncompressed_compute_extent(pa) )
 	{
-        pc_patch_free(pa);
+        pc_patch_free((PCPATCH *)pa);
 		pcerror("%s: bounds computation failed", __func__);
 		return NULL;
 	}
 	
 	if ( pa && PC_FAILURE == pc_patch_uncompressed_compute_stats(pa) )
 	{
-        pc_patch_free(pa);
+        pc_patch_free((PCPATCH *)pa);
 		pcerror("%s: stats computation failed", __func__);
 		return NULL;
 	}
 
-    return pa;
+    return (PCPATCH *)pa;
 }


### PR DESCRIPTION
This fixes typing errors in pc_interp.c, removing -Wdiscarded-qualifiers and -Wincompatible-pointer-types warnings when compiling pc_interp.c.

This is the current output of the pc_interp.c compilation:

```
[ 23%] Building C object lib/CMakeFiles/libpc-static.dir/pc_interp.c.o                                                                                                                                             
/home/elemoine/src/pointcloud/lib/pc_interp.c: In function ‘blower_arg’:                                                                                                                                           
/home/elemoine/src/pointcloud/lib/pc_interp.c:53:12: warning: return discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]                                                                  
     return base;                                                                                                                                                                                                  
            ^~~~                                                                                                                                                                                                   
/home/elemoine/src/pointcloud/lib/pc_interp.c: In function ‘pc_patch_uncompressed_interp’:                                                                                                                         
/home/elemoine/src/pointcloud/lib/pc_interp.c:176:19: warning: passing argument 1 of ‘pc_patch_free’ from incompatible pointer type [-Wincompatible-pointer-types]                                                 
     pc_patch_free(pa);                                                                                                                                                                                            
                   ^~                                                                                                                                                                                              
In file included from /home/elemoine/src/pointcloud/lib/pc_api_internal.h:18:0,                                                                                                                                    
                 from /home/elemoine/src/pointcloud/lib/pc_interp.c:14:                                                                                                                                            
/home/elemoine/src/pointcloud/lib/pc_api.h:372:6: note: expected ‘PCPATCH * {aka struct <anonymous> *}’ but argument is of type ‘PCPATCH_UNCOMPRESSED * {aka struct <anonymous> *}’                                
 void pc_patch_free(PCPATCH *patch);                                                                                                                                                                               
      ^~~~~~~~~~~~~                                                                                                                                                                                                
/home/elemoine/src/pointcloud/lib/pc_interp.c: In function ‘pc_patch_interp’:                                                                                                                                      
/home/elemoine/src/pointcloud/lib/pc_interp.c:233:64: warning: passing argument 1 of ‘pc_patch_uncompressed_compute_extent’ from incompatible pointer type [-Wincompatible-pointer-types]                          
  if ( pa && PC_FAILURE == pc_patch_uncompressed_compute_extent(pa) )                                                                                                                                              
                                                                ^~                                                                                                                                                 
In file included from /home/elemoine/src/pointcloud/lib/pc_interp.c:14:0:                                                                                                                                          
/home/elemoine/src/pointcloud/lib/pc_api_internal.h:182:5: note: expected ‘PCPATCH_UNCOMPRESSED * {aka struct <anonymous> *}’ but argument is of type ‘PCPATCH * {aka struct <anonymous> *}’                       
 int pc_patch_uncompressed_compute_extent(PCPATCH_UNCOMPRESSED *patch);                                                                                                                                            
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                          
/home/elemoine/src/pointcloud/lib/pc_interp.c:240:63: warning: passing argument 1 of ‘pc_patch_uncompressed_compute_stats’ from incompatible pointer type [-Wincompatible-pointer-types]                           
  if ( pa && PC_FAILURE == pc_patch_uncompressed_compute_stats(pa) )                                                                                                                                               
                                                               ^~                                                                                                                                                  
In file included from /home/elemoine/src/pointcloud/lib/pc_interp.c:14:0:                                                                                                                                          
/home/elemoine/src/pointcloud/lib/pc_api_internal.h:183:5: note: expected ‘PCPATCH_UNCOMPRESSED * {aka struct <anonymous> *}’ but argument is of type ‘PCPATCH * {aka struct <anonymous> *}’                       
 int pc_patch_uncompressed_compute_stats(PCPATCH_UNCOMPRESSED *patch);                                                                                                                                             
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```