### PR TITLE
Add PC_RotateQuaternion

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,16 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 >     SELECT PC_RotateQuaternion(pa, cos(angle.value / 2.0), sin(angle.value / 2.0), 0, 0, 'x', 'y', 'z')
 >     FROM patches, angle;
 
+**PC_RotateQuaternion(p pcpoint, qw float8, qx float8, qy float8, qz float8, xdimname text, ydimname text, zdimname text)** returns **pcpoint**
+
+> Rotate a point given a unit quaternion (qw, qx, qy, qz). For example this how to rotate points by π/2 around the x axis:
+>
+>     WITH angle(value) AS (
+>       SELECT pi()/2.0
+>     )
+>     SELECT PC_RotateQuaternion(pt, cos(angle.value / 2.0), sin(angle.value / 2.0), 0, 0, 'x', 'y', 'z')
+>     FROM points, angle;
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/README.md
+++ b/README.md
@@ -485,6 +485,16 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 > Sets the schema on a PcPatch, given a valid `pcid` schema number. The internal values of the points may change for dimensions where the offset and/or scale are different between the "old" and the "new" schema, so that the corresponding double values are unchanged, up to the precision of the underlying representation. Also, 0 values will be used for dimensions that are in the new schema but not in the old schema. And the values of dimensions that are in the old schema but not in the new schema will be discarded.
 
+**PC_RotateQuaternion(p pcpatch, qw float8, qx float8, qy float8, qz float8, xdimname text, ydimname text, zdimname text)** returns **pcpatch**
+
+> Rotate a patch given a unit quaternion (qw, qx, qy, qz). For example this how to rotate patches by π/2 around the x axis:
+>
+>     WITH angle(value) AS (
+>       SELECT pi()/2.0
+>     )
+>     SELECT PC_RotateQuaternion(pa, cos(angle.value / 2.0), sin(angle.value / 2.0), 0, 0, 'x', 'y', 'z')
+>     FROM patches, angle;
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ set ( PC_SOURCES
         pc_dimstats.c      
         pc_filter.c    
         pc_interp.c
+        pc_matrix.c
         pc_mem.c 
         pc_patch.c
         pc_patch_dimensional.c

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,6 +6,7 @@ LDFLAGS = $(XML2_LDFLAGS) $(ZLIB_LDFLAGS) $(GHT_LDFLASGS)
 CFLAGS += -fPIC
 
 OBJS = \
+	pc_matrix.o \
 	pc_bytes.o \
 	pc_dimstats.o \
 	pc_filter.o \

--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -7,6 +7,7 @@
 *
 ***********************************************************************/
 
+#include <math.h>
 #include "CUnit/Basic.h"
 #include "cu_tester.h"
 
@@ -1094,6 +1095,190 @@ test_patch_set_schema_dimensional_compression_rle()
     test_patch_set_schema_dimensional_compression(PC_DIM_RLE);
 }
 
+static void
+test_patch_rotate_quaternion_compression_none()
+{
+    PCPATCH *patch;
+    PCPATCH_UNCOMPRESSED *patch_uncompressed;
+    PCPOINTLIST *pl;
+    PCPOINT *pt;
+    double angle;
+    double qw, qx, qy, qz;
+    double v;
+
+    // (1, 1, 1) is the point we're going to rotate
+    pl = pc_pointlist_make(1);
+    pt = pc_point_make(simplexyzschema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    pc_pointlist_add_point(pl, pt);
+
+    // π/2 rotation around x axis
+    // expected result: (1, -1, 1)
+    patch_uncompressed = pc_patch_uncompressed_from_pointlist(pl);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = sin(angle / 2.);
+    qy = 0;
+    qz = 0;
+    patch = pc_patch_rotate_quaternion(
+            (PCPATCH *)patch_uncompressed, qw, qx, qy, qz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == -1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 1);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH*)patch_uncompressed);
+
+    // π/2 rotation around y axis
+    // expected result: (1, 1, -1)
+    patch_uncompressed = pc_patch_uncompressed_from_pointlist(pl);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = 0;
+    qy = sin(angle / 2.);
+    qz = 0;
+    patch = pc_patch_rotate_quaternion(
+            (PCPATCH *)patch_uncompressed, qw, qx, qy, qz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == -1);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH*)patch_uncompressed);
+
+    // π/2 rotation around z axis
+    // expected result: (-1, 1, 1)
+    patch_uncompressed = pc_patch_uncompressed_from_pointlist(pl);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = 0;
+    qy = 0;
+    qz = sin(angle / 2.);
+    patch = pc_patch_rotate_quaternion(
+            (PCPATCH *)patch_uncompressed, qw, qx, qy, qz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == -1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 1);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH*)patch_uncompressed);
+
+    pc_pointlist_free(pl);
+}
+
+#ifdef HAVE_LIBGHT
+static void
+test_patch_rotate_quaternion_compression_ght()
+{
+    PCPATCH *patch;
+    PCPATCH_GHT *patch_ght;
+    PCPOINTLIST *pl;
+    PCPOINT *pt;
+    double angle;
+    double qw, qx, qy, qz;
+    double v;
+
+    // (1, 1, 1) is the point we're going to rotate
+    pl = pc_pointlist_make(1);
+    pt = pc_point_make(simplexyzschema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    pc_pointlist_add_point(pl, pt);
+
+    // π/2 rotation around x axis
+    // expected result: (1, -1, 1)
+    patch_ght = pc_patch_ght_from_pointlist(pl);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = sin(angle / 2.);
+    qy = 0;
+    qz = 0;
+    patch = pc_patch_rotate_quaternion(
+            (PCPATCH *)patch_ght, qw, qx, qy, qz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == -1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 1);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH *)patch_ght);
+
+    // π/2 rotation around y axis
+    // expected result: (1, 1, -1)
+    patch_ght = pc_patch_ght_from_pointlist(pl);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = 0;
+    qy = sin(angle / 2.);
+    qz = 0;
+    patch = pc_patch_rotate_quaternion(
+            (PCPATCH *)patch_ght, qw, qx, qy, qz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == -1);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH *)patch_ght);
+
+    // π/2 rotation around z axis
+    // expected result: (-1, 1, 1)
+    patch_ght = pc_patch_ght_from_pointlist(pl);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = 0;
+    qy = 0;
+    qz = sin(angle / 2.);
+    patch = pc_patch_rotate_quaternion(
+            (PCPATCH *)patch_ght, qw, qx, qy, qz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == -1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 1);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH *)patch_ght);
+
+    pc_pointlist_free(pl);
+}
+#endif  /* HAVE_LIBGHT */
+
 /* REGISTER ***********************************************************/
 
 CU_TestInfo patch_tests[] = {
@@ -1130,6 +1315,10 @@ CU_TestInfo patch_tests[] = {
 	PC_TEST(test_patch_set_schema_dimensional_compression_rle),
 #ifdef HAVE_LAZPERF
 	PC_TEST(test_patch_set_schema_compression_lazperf),
+#endif
+    PC_TEST(test_patch_rotate_quaternion_compression_none),
+#ifdef HAVE_LIBGHT
+    PC_TEST(test_patch_rotate_quaternion_compression_ght),
 #endif
 	CU_TEST_INFO_NULL
 };

--- a/lib/cunit/cu_pc_point.c
+++ b/lib/cunit/cu_pc_point.c
@@ -152,11 +152,81 @@ test_point_access()
 
 }
 
+static void
+test_point_rotate_quaternion()
+{
+    PCPOINT *pt;
+    double angle;
+    double qw, qx, qy, qz;
+    double v;
+
+    // π/2 rotation of point (1, 1, 1) around x axis
+    // expected result: (1, -1, 1)
+	pt = pc_point_make(schema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = sin(angle / 2.);
+    qy = 0;
+    qz = 0;
+    pc_point_rotate_quaternion(pt, qw, qx, qy, qz, "x", "y", "z");
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == -1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 1);
+    pc_point_free(pt);
+
+    // π/2 rotation of point (1, 1, 1) around y axis
+    // expected result: (1, 1, -1)
+	pt = pc_point_make(schema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = 0;
+    qy = sin(angle / 2.);
+    qz = 0;
+    pc_point_rotate_quaternion(pt, qw, qx, qy, qz, "x", "y", "z");
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == -1);
+    pc_point_free(pt);
+
+    // π/2 rotation of point (1, 1, 1) around z axis
+    // expected result: (-1, 1, 1)
+	pt = pc_point_make(schema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    angle = M_PI_2;
+    qw = cos(angle / 2.);
+    qx = 0;
+    qy = 0;
+    qz = sin(angle / 2.);
+    pc_point_rotate_quaternion(pt, qw, qx, qy, qz, "x", "y", "z");
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == -1);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 1);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 1);
+    pc_point_free(pt);
+}
+
 /* REGISTER ***********************************************************/
 
 CU_TestInfo point_tests[] = {
 	PC_TEST(test_point_hex_inout),
 	PC_TEST(test_point_access),
+    PC_TEST(test_point_rotate_quaternion),
 	CU_TEST_INFO_NULL
 };
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -451,4 +451,7 @@ PCPATCH* pc_patch_range(const PCPATCH *pa, int first, int cound);
 /** assign a schema to the patch */
 PCPATCH *pc_patch_set_schema(const PCPATCH *patch, const PCSCHEMA *schema);
 
+/** rotate a patch given a unit quaternion */
+PCPATCH *pc_patch_rotate_quaternion(const PCPATCH *patch, double qw, double qx, double qy, double qz, const char *xdimname, const char *ydimname, const char *zdimname);
+
 #endif /* _PC_API_H */

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -454,4 +454,7 @@ PCPATCH *pc_patch_set_schema(const PCPATCH *patch, const PCSCHEMA *schema);
 /** rotate a patch given a unit quaternion */
 PCPATCH *pc_patch_rotate_quaternion(const PCPATCH *patch, double qw, double qx, double qy, double qz, const char *xdimname, const char *ydimname, const char *zdimname);
 
+/** rotate a point in place given a unit quaternion */
+void pc_point_rotate_quaternion(PCPOINT *point, double qw, double qx, double qy, double qz, const char *xdimname, const char *ydimname, const char *zdimname);
+
 #endif /* _PC_API_H */

--- a/lib/pc_api_internal.h
+++ b/lib/pc_api_internal.h
@@ -87,6 +87,10 @@ typedef struct
 	uint8_t *map;
 } PCBITMAP;
 
+/* */
+typedef double PCMAT33[9];
+typedef double PCVEC3[3];
+
 
 /** What is the endianness of this system? */
 char machine_endian(void);
@@ -290,7 +294,12 @@ void pc_bitmap_filter(PCBITMAP *map, PC_FILTERTYPE filter, int i, double d, doub
 /** Read indicated bit of bitmap */
 #define pc_bitmap_get(map, i) ((map)->map[(i)])
 
+/****************************************************************************
+* MATRIX
+*/
 
+void pc_matrix_set_from_quaternion(PCMAT33 mat, double qw, double qx, double qy, double qz);
+void pc_matrix_multiply_vector(PCVEC3 rotatedvec, const PCMAT33 mat, const PCVEC3 vec);
 
 #endif /* _PC_API_INTERNAL_H */
 

--- a/lib/pc_matrix.c
+++ b/lib/pc_matrix.c
@@ -1,0 +1,63 @@
+/***********************************************************************
+* pc_matrix.c
+*
+*  Simple matrix library.
+*  Allow this library to be used both inside and outside a
+*  PgSQL backend.
+*
+*  PgSQL Pointcloud is free and open source software provided
+*  by the Government of Canada
+*  Copyright (c) 2013 Natural Resources Canada
+*  Copyright (c) 2017 Oslandia
+*
+***********************************************************************/
+
+#include "pc_api_internal.h"
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/**
+* Sets the 3x3 matrix mat associated to the (qw, qx, qy, qz) quaternion. Assume
+* that the quaternion is a unit quaternion.
+*/
+void
+pc_matrix_set_from_quaternion(PCMAT33 mat, double qw, double qx, double qy, double qz)
+{
+    double x = qx+qx;
+    double y = qy+qy;
+    double z = qz+qz;
+
+    double xx = qx * x;
+    double xy = qx * y;
+    double xz = qx * z;
+    double yy = qy * y;
+    double yz = qy * z;
+    double zz = qz * z;
+    double wx = qw * x;
+    double wy = qw * y;
+    double wz = qw * z;
+
+    mat[0] = 1 - ( yy + zz );
+    mat[1] = xy - wz;
+    mat[2] = xz + wy;
+
+    mat[3] = xy + wz;
+    mat[4] = 1 - ( xx + zz );
+    mat[5] = yz - wx;
+
+    mat[6] = xz - wy;
+    mat[7] = yz + wx;
+    mat[8] = 1 - ( xx + yy );
+}
+
+/**
+* Multiply mat by vec and store the resuting vector in res.
+*/
+void
+pc_matrix_multiply_vector(PCVEC3 res, const PCMAT33 mat, const PCVEC3 vec)
+{
+    res[0] = mat[0] * vec[0] + mat[1] * vec[1] + mat[2] * vec[2];
+    res[1] = mat[3] * vec[0] + mat[4] * vec[1] + mat[5] * vec[2];
+    res[2] = mat[6] * vec[0] + mat[7] * vec[1] + mat[8] * vec[2];
+}

--- a/lib/pc_point.c
+++ b/lib/pc_point.c
@@ -375,3 +375,37 @@ double * pc_point_to_double_array(const PCPOINT *p)
 
 	return a;
 }
+
+/**
+* Rotate a point in place given a unit quaternion.
+*/
+void
+pc_point_rotate_quaternion(
+    PCPOINT *point,
+    double qw, double qx, double qy, double qz,
+    const char *xdimname, const char *ydimname, const char *zdimname)
+{
+    const PCSCHEMA *schema;
+    const PCDIMENSION *xdim, *ydim, *zdim;
+    PCMAT33 qmat;
+    PCVEC3 vec, rvec;
+
+    pc_matrix_set_from_quaternion(qmat, qw, qx, qy, qz);
+
+    schema = point->schema;
+ 
+    xdim = pc_schema_get_dimension_by_name(schema, xdimname);
+    ydim = pc_schema_get_dimension_by_name(schema, ydimname);
+    zdim = pc_schema_get_dimension_by_name(schema, zdimname);
+
+    pc_point_get_double(point, xdim, &vec[0]);
+    pc_point_get_double(point, ydim, &vec[1]);
+    pc_point_get_double(point, zdim, &vec[2]);
+
+    pc_matrix_multiply_vector(rvec, qmat, vec);
+
+    pc_point_set_double(point, xdim, rvec[0]);
+    pc_point_set_double(point, ydim, rvec[1]);
+    pc_point_set_double(point, zdim, rvec[2]);
+
+}

--- a/pgsql/CMakeLists.txt
+++ b/pgsql/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set ( PC_SOURCES
   pc_access.c 
+  pc_editor.c
   pc_inout.c      
   pc_pgsql.c       
   )

--- a/pgsql/Makefile
+++ b/pgsql/Makefile
@@ -5,6 +5,7 @@ include ../config.mk
 OBJS = \
 	pc_inout.o \
 	pc_access.o \
+	pc_editor.o \
 	pc_pgsql.o
 
 SED = sed

--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -64,3 +64,48 @@ Datum pcpatch_rotate_quaternion(PG_FUNCTION_ARGS)
 
     PG_RETURN_POINTER(serpatch);
 }
+
+/**
+* Rotate a point based on a rotation quaternion
+* PC_RotateQuaternion(point pcpoint, qw float8, qx float8, qy float8, qz float8,
+*                     xdimname text, ydimname text, zdimname text) returns pcpoint
+*/
+PG_FUNCTION_INFO_V1(pcpoint_rotate_quaternion);
+Datum pcpoint_rotate_quaternion(PG_FUNCTION_ARGS)
+{
+    SERIALIZED_POINT *serpoint;
+    PCPOINT *point;
+    PCSCHEMA *schema;
+    float8 qw, qx, qy, qz;
+    char *xdimname, *ydimname, *zdimname;
+
+    if ( PG_ARGISNULL(0) )
+        PG_RETURN_NULL();   /* returns null if no input values */
+
+    serpoint = PG_GETARG_SERPOINT_P(0);
+    qw = PG_GETARG_FLOAT8(1);
+    qx = PG_GETARG_FLOAT8(2);
+    qy = PG_GETARG_FLOAT8(3);
+    qz = PG_GETARG_FLOAT8(4);
+    xdimname = text_to_cstring(PG_GETARG_TEXT_P(5));
+    ydimname = text_to_cstring(PG_GETARG_TEXT_P(6));
+    zdimname = text_to_cstring(PG_GETARG_TEXT_P(7));
+
+    schema = pc_schema_from_pcid(serpoint->pcid, fcinfo);
+
+    point = pc_point_deserialize(serpoint, schema);
+    if ( ! point )
+    {
+        elog(ERROR, "failed to deserialize point");
+        PG_RETURN_NULL();
+    }
+
+    pc_point_rotate_quaternion(
+        point, qw, qx, qy, qz, xdimname, ydimname, zdimname);
+
+    serpoint = pc_point_serialize(point);
+
+    pc_point_free(point);
+
+    PG_RETURN_POINTER(serpoint);
+}

--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -1,0 +1,66 @@
+/***********************************************************************
+* pc_editor.c
+*
+*  Editor functions for points and patches in PgSQL.
+*
+*  PgSQL Pointcloud is free and open source software provided
+*  by the Government of Canada
+*  Copyright (c) 2013 Natural Resources Canada
+*  Copyright (c) 2017 Oslandia
+*
+***********************************************************************/
+
+#include "pc_pgsql.h"      /* Common PgSQL support for our type */
+
+Datum pcpatch_rotate_quaternion(PG_FUNCTION_ARGS);
+
+/**
+* Rotate a patch based on a rotation quaternion
+* PC_RotateQuaternion(patch pcpatch, qw float8, qx float8, qy float8, qz float8,
+*                     xdimname text, ydimname text, zdimname text) returns pcpatch
+*/
+PG_FUNCTION_INFO_V1(pcpatch_rotate_quaternion);
+Datum pcpatch_rotate_quaternion(PG_FUNCTION_ARGS)
+{
+    SERIALIZED_PATCH *serpatch;
+    PCPATCH *patch_in, *patch_out;
+    PCSCHEMA *schema;
+    float8 qw, qx, qy, qz;
+    char *xdimname, *ydimname, *zdimname;
+
+    if ( PG_ARGISNULL(0) )
+        PG_RETURN_NULL();   /* returns null if no input values */
+
+    serpatch = PG_GETARG_SERPATCH_P(0);
+    qw = PG_GETARG_FLOAT8(1);
+    qx = PG_GETARG_FLOAT8(2);
+    qy = PG_GETARG_FLOAT8(3);
+    qz = PG_GETARG_FLOAT8(4);
+    xdimname = text_to_cstring(PG_GETARG_TEXT_P(5));
+    ydimname = text_to_cstring(PG_GETARG_TEXT_P(6));
+    zdimname = text_to_cstring(PG_GETARG_TEXT_P(7));
+
+    schema = pc_schema_from_pcid(serpatch->pcid, fcinfo);
+
+    patch_in = pc_patch_deserialize(serpatch, schema);
+    if ( ! patch_in )
+    {
+        elog(ERROR, "failed to deserialize patch");
+        PG_RETURN_NULL();
+    }
+
+    patch_out = pc_patch_rotate_quaternion(
+        patch_in, qw, qx, qy, qz, xdimname, ydimname, zdimname);
+    if ( ! patch_out )
+    {
+        elog(ERROR, "failed to rotate patch");
+        PG_RETURN_NULL();
+    }
+
+    serpatch = pc_patch_serialize(patch_out, NULL);
+
+    pc_patch_free(patch_in);
+    pc_patch_free(patch_out);
+
+    PG_RETURN_POINTER(serpatch);
+}

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -322,6 +322,10 @@ CREATE OR REPLACE FUNCTION PC_RotateQuaternion(p pcpatch, qw float8, qx float8, 
     RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_rotate_quaternion'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_RotateQuaternion(p pcpoint, qw float8, qx float8, qy float8, qz float8, xdimname text, ydimname text, zdimname text)
+    RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_rotate_quaternion'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -318,6 +318,10 @@ CREATE OR REPLACE FUNCTION PC_SetPCID(p pcpatch, pcid int4)
     RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_setpcid'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_RotateQuaternion(p pcpatch, qw float8, qx float8, qy float8, qz float8, xdimname text, ydimname text, zdimname text)
+    RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_rotate_quaternion'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
This PR adds `PC_RotateQuaternion` to rotate patches based on rotation quaternions.