### PR TITLE
Use a small optimization in pc_patch_set_schema

### DIFF
--- a/lib/pc_patch.c
+++ b/lib/pc_patch.c
@@ -645,7 +645,7 @@ pc_patch_set_schema(const PCPATCH *patch, const PCSCHEMA *new_schema)
 
             val = 0.0;
             if ( dim != NULL )
-                pc_point_get_double_by_name(opt, name, &val);
+                pc_point_get_double(opt, dim, &val);
 
             pc_point_set_double(npt, new_schema->dims[j], val);
         }


### PR DESCRIPTION
We have a reference to the dimension object, so the lookup by name is not necessary.

(Caught by @mbredif)