### PR TITLE
Add PC_Translate for patches and points

### DIFF
--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -1279,6 +1279,92 @@ test_patch_rotate_quaternion_compression_ght()
 }
 #endif  /* HAVE_LIBGHT */
 
+static void
+test_patch_translate_compression_none()
+{
+    PCPATCH *patch;
+    PCPATCH_UNCOMPRESSED *patch_uncompressed;
+    PCPOINTLIST *pl;
+    PCPOINT *pt;
+    double tx, ty, tz;
+    double v;
+
+    // (1, 1, 1) is the point we're going to translate
+    pl = pc_pointlist_make(1);
+    pt = pc_point_make(simplexyzschema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    pc_pointlist_add_point(pl, pt);
+
+    // (-1, 1, 2) translation
+    // expected result: (0, 2, 3)
+    patch_uncompressed = pc_patch_uncompressed_from_pointlist(pl);
+    tx = -1.0;
+    ty = 1.0;
+    tz = 2.0;
+    patch = pc_patch_translate(
+            (PCPATCH *)patch_uncompressed, tx, ty, tz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 0);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 2);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 3);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH*)patch_uncompressed);
+
+    pc_pointlist_free(pl);
+}
+
+#ifdef HAVE_LIBGHT
+static void
+test_patch_translate_compression_ght()
+{
+    PCPATCH *patch;
+    PCPATCH_GHT *patch_ght;
+    PCPOINTLIST *pl;
+    PCPOINT *pt;
+    double tx, ty, tz;
+    double v;
+
+    // (1, 1, 1) is the point we're going to translate
+    pl = pc_pointlist_make(1);
+    pt = pc_point_make(simplexyzschema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    pc_pointlist_add_point(pl, pt);
+
+    // (-1, 1, 2) translation
+    // expected result: (0, 2, 3)
+    patch_ght = pc_patch_ght_from_pointlist(pl);
+    tx = -1.0;
+    ty = 1.0;
+    tz = 2.0;
+    patch = pc_patch_translate(
+            (PCPATCH *)patch_ght, tx, ty, tz, "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 0);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 2);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 3);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH *)patch_ght);
+
+    pc_pointlist_free(pl);
+}
+#endif  /* HAVE_LIBGHT */
+
 /* REGISTER ***********************************************************/
 
 CU_TestInfo patch_tests[] = {
@@ -1319,6 +1405,10 @@ CU_TestInfo patch_tests[] = {
     PC_TEST(test_patch_rotate_quaternion_compression_none),
 #ifdef HAVE_LIBGHT
     PC_TEST(test_patch_rotate_quaternion_compression_ght),
+#endif
+    PC_TEST(test_patch_translate_compression_none),
+#ifdef HAVE_LIBGHT
+    PC_TEST(test_patch_translate_compression_ght),
 #endif
 	CU_TEST_INFO_NULL
 };

--- a/lib/cunit/cu_pc_point.c
+++ b/lib/cunit/cu_pc_point.c
@@ -220,12 +220,39 @@ test_point_rotate_quaternion()
     pc_point_free(pt);
 }
 
+static void
+test_point_translate()
+{
+    PCPOINT *pt;
+    double tx, ty, tz;
+    double v;
+
+    // translation of point (1, 1, 1) by (-1, 1, 2)
+    // expected result: (0, 2, 3)
+    pt = pc_point_make(schema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    tx = -1.0;
+    ty = 1.0;
+    tz = 2.0;
+    pc_point_translate(pt, tx, ty, tz, "x", "y", "z");
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 0);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 2);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 3);
+    pc_point_free(pt);
+}
+
 /* REGISTER ***********************************************************/
 
 CU_TestInfo point_tests[] = {
 	PC_TEST(test_point_hex_inout),
 	PC_TEST(test_point_access),
     PC_TEST(test_point_rotate_quaternion),
+    PC_TEST(test_point_translate),
 	CU_TEST_INFO_NULL
 };
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -463,4 +463,7 @@ PCPATCH *pc_patch_rotate_quaternion(const PCPATCH *patch, double qw, double qx, 
 /** rotate a point in place given a unit quaternion */
 void pc_point_rotate_quaternion(PCPOINT *point, double qw, double qx, double qy, double qz, const char *xdimname, const char *ydimname, const char *zdimname);
 
+/** translate a patch */
+PCPATCH *pc_patch_translate(const PCPATCH *patch, double tx, double ty, double tz, const char *xdimname, const char *ydimname, const char *zdimname);
+
 #endif /* _PC_API_H */

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -466,4 +466,7 @@ void pc_point_rotate_quaternion(PCPOINT *point, double qw, double qx, double qy,
 /** translate a patch */
 PCPATCH *pc_patch_translate(const PCPATCH *patch, double tx, double ty, double tz, const char *xdimname, const char *ydimname, const char *zdimname);
 
+/** translate a point */
+void pc_point_translate(PCPOINT *point, double tx, double ty, double tz, const char *xdimname, const char *ydimname, const char *zdimname);
+
 #endif /* _PC_API_H */

--- a/lib/pc_point.c
+++ b/lib/pc_point.c
@@ -409,3 +409,31 @@ pc_point_rotate_quaternion(
     pc_point_set_double(point, zdim, rvec[2]);
 
 }
+
+/**
+* Translate a point.
+*/
+void
+pc_point_translate(
+    PCPOINT *point,
+    double tx, double ty, double tz,
+    const char *xdimname, const char *ydimname, const char *zdimname)
+{
+    const PCSCHEMA *schema;
+    const PCDIMENSION *xdim, *ydim, *zdim;
+    double x, y, z;
+
+    schema = point->schema;
+
+    xdim = pc_schema_get_dimension_by_name(schema, xdimname);
+    ydim = pc_schema_get_dimension_by_name(schema, ydimname);
+    zdim = pc_schema_get_dimension_by_name(schema, zdimname);
+
+    pc_point_get_double(point, xdim, &x);
+    pc_point_get_double(point, ydim, &y);
+    pc_point_get_double(point, zdim, &z);
+
+    pc_point_set_double(point, xdim, x + tx);
+    pc_point_set_double(point, ydim, y + ty);
+    pc_point_set_double(point, zdim, z + tz);
+}

--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -109,3 +109,53 @@ Datum pcpoint_rotate_quaternion(PG_FUNCTION_ARGS)
 
     PG_RETURN_POINTER(serpoint);
 }
+
+/**
+* Translate a patch
+* PC_Translate(patch pcpatch, tx float8, ty float8, tz float8,
+*              xdimname text, ydimname text, zdimname text) returns pcpatch
+*/
+PG_FUNCTION_INFO_V1(pcpatch_translate);
+Datum pcpatch_translate(PG_FUNCTION_ARGS)
+{
+    SERIALIZED_PATCH *serpatch;
+    PCPATCH *patch_in, *patch_out;
+    PCSCHEMA *schema;
+    float8 tx, ty, tz;
+    char *xdimname, *ydimname, *zdimname;
+
+    if ( PG_ARGISNULL(0) )
+        PG_RETURN_NULL();   /* returns null if no input values */
+
+    serpatch = PG_GETARG_SERPATCH_P(0);
+    tx = PG_GETARG_FLOAT8(1);
+    ty = PG_GETARG_FLOAT8(2);
+    tz = PG_GETARG_FLOAT8(3);
+    xdimname = text_to_cstring(PG_GETARG_TEXT_P(4));
+    ydimname = text_to_cstring(PG_GETARG_TEXT_P(5));
+    zdimname = text_to_cstring(PG_GETARG_TEXT_P(6));
+
+    schema = pc_schema_from_pcid(serpatch->pcid, fcinfo);
+
+    patch_in = pc_patch_deserialize(serpatch, schema);
+    if ( ! patch_in )
+    {
+        elog(ERROR, "failed to deserialize patch");
+        PG_RETURN_NULL();
+    }
+
+    patch_out = pc_patch_translate(
+        patch_in, tx, ty, tz, xdimname, ydimname, zdimname);
+    if ( ! patch_out )
+    {
+        elog(ERROR, "failed to rotate patch");
+        PG_RETURN_NULL();
+    }
+
+    serpatch = pc_patch_serialize(patch_out, NULL);
+
+    pc_patch_free(patch_in);
+    pc_patch_free(patch_out);
+
+    PG_RETURN_POINTER(serpatch);
+}

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -334,6 +334,10 @@ CREATE OR REPLACE FUNCTION PC_RotateQuaternion(p pcpoint, qw float8, qx float8, 
     RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_rotate_quaternion'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Translate(p pcpatch, tx float8, ty float8, tz float8, xdimname text, ydimname text, zdimname text)
+    RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_translate'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -338,6 +338,10 @@ CREATE OR REPLACE FUNCTION PC_Translate(p pcpatch, tx float8, ty float8, tz floa
     RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_translate'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Translate(p pcpoint, tx float8, ty float8, tz float8, xdimname text, ydimname text, zdimname text)
+    RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_translate'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
This PR adds `PC_Translate(pcpatch)` and `PC_Translate(pcpoint)` for translating patches and points, respectively.