### PR TITLE
Add PC_Affine for patches and points

### DIFF
--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -1365,6 +1365,114 @@ test_patch_translate_compression_ght()
 }
 #endif  /* HAVE_LIBGHT */
 
+static void
+test_patch_affine_compression_none()
+{
+    PCPATCH *patch;
+    PCPATCH_UNCOMPRESSED *patch_uncompressed;
+    PCPOINTLIST *pl;
+    PCPOINT *pt;
+    double a, b, c, d, e, f, g, h, i;
+    double xoff, yoff, zoff;
+    double v;
+
+    // (1, 1, 1) is the point we're going to transform
+    pl = pc_pointlist_make(1);
+    pt = pc_point_make(simplexyzschema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    pc_pointlist_add_point(pl, pt);
+
+    // scale + translate
+    patch_uncompressed = pc_patch_uncompressed_from_pointlist(pl);
+    a = 2;
+    b = 0;
+    c = 0;
+    d = 0;
+    e = 2;
+    f = 0;
+    g = 0;
+    h = 0;
+    i = 2;
+    xoff = 1;
+    yoff = 1;
+    zoff = 1;
+    patch = pc_patch_affine(
+            (PCPATCH *)patch_uncompressed,
+            a, b, c, d, e, f, g, h, i, xoff, yoff, zoff,
+            "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 3);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 3);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 3);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH*)patch_uncompressed);
+
+    pc_pointlist_free(pl);
+}
+
+#ifdef HAVE_LIBGHT
+static void
+test_patch_affine_compression_ght()
+{
+    PCPATCH *patch;
+    PCPATCH_GHT *patch_ght;
+    PCPOINTLIST *pl;
+    PCPOINT *pt;
+    double a, b, c, d, e, f, g, h, i;
+    double xoff, yoff, zoff;
+    double v;
+
+    // (1, 1, 1) is the point we're going to transform
+    pl = pc_pointlist_make(1);
+    pt = pc_point_make(simplexyzschema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    pc_pointlist_add_point(pl, pt);
+
+    // scale + translate
+    patch_ght = pc_patch_ght_from_pointlist(pl);
+    a = 2;
+    b = 0;
+    c = 0;
+    d = 0;
+    e = 2;
+    f = 0;
+    g = 0;
+    h = 0;
+    i = 2;
+    xoff = 1;
+    yoff = 1;
+    zoff = 1;
+    patch = pc_patch_affine(
+            (PCPATCH *)patch_ght,
+            a, b, c, d, e, f, g, h, i, xoff, yoff, zoff,
+            "x", "y", "z");
+    CU_ASSERT(patch != NULL);
+    pt = pc_patch_pointn(patch, 1);
+    CU_ASSERT(pt != NULL);
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 3);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 3);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 3);
+    pc_point_free(pt);
+    pc_patch_free(patch);
+    pc_patch_free((PCPATCH*)patch_ght);
+
+    pc_pointlist_free(pl);
+}
+#endif  /* HAVE_LIBGHT */
+
 /* REGISTER ***********************************************************/
 
 CU_TestInfo patch_tests[] = {
@@ -1409,6 +1517,10 @@ CU_TestInfo patch_tests[] = {
     PC_TEST(test_patch_translate_compression_none),
 #ifdef HAVE_LIBGHT
     PC_TEST(test_patch_translate_compression_ght),
+#endif
+    PC_TEST(test_patch_affine_compression_none),
+#ifdef HAVE_LIBGHT
+    PC_TEST(test_patch_affine_compression_ght),
 #endif
 	CU_TEST_INFO_NULL
 };

--- a/lib/cunit/cu_pc_point.c
+++ b/lib/cunit/cu_pc_point.c
@@ -246,6 +246,44 @@ test_point_translate()
     pc_point_free(pt);
 }
 
+static void
+test_point_affine()
+{
+    PCPOINT *pt;
+    double a, b, c, d, e, f, g, h, i;
+    double xoff, yoff, zoff;
+    double v;
+
+    // scale + translate
+	pt = pc_point_make(schema);
+    pc_point_set_double_by_name(pt, "x", 1.0);
+    pc_point_set_double_by_name(pt, "y", 1.0);
+    pc_point_set_double_by_name(pt, "z", 1.0);
+    a = 2;
+    b = 0;
+    c = 0;
+    d = 0;
+    e = 2;
+    f = 0;
+    g = 0;
+    h = 0;
+    i = 2;
+    xoff = 1;
+    yoff = 1;
+    zoff = 1;
+    pc_point_affine(
+            pt,
+            a, b, c, d, e, f, g, h, i, xoff, yoff, zoff,
+            "x", "y", "z");
+    pc_point_get_double_by_name(pt, "x", &v);
+    CU_ASSERT(v == 3);
+    pc_point_get_double_by_name(pt, "y", &v);
+    CU_ASSERT(v == 3);
+    pc_point_get_double_by_name(pt, "z", &v);
+    CU_ASSERT(v == 3);
+    pc_point_free(pt);
+}
+
 /* REGISTER ***********************************************************/
 
 CU_TestInfo point_tests[] = {
@@ -253,6 +291,7 @@ CU_TestInfo point_tests[] = {
 	PC_TEST(test_point_access),
     PC_TEST(test_point_rotate_quaternion),
     PC_TEST(test_point_translate),
+    PC_TEST(test_point_affine),
 	CU_TEST_INFO_NULL
 };
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -472,4 +472,7 @@ void pc_point_translate(PCPOINT *point, double tx, double ty, double tz, const c
 /** apply an affine transformation to a patch */
 PCPATCH *pc_patch_affine(const PCPATCH *patch, double a, double b, double c, double d, double e, double f, double g, double h, double i, double xoff, double yoff, double zoff, const char *xdimname, const char *ydimname, const char *zdimname);
 
+/** apply an affine transformation to a patch */
+void pc_point_affine(PCPOINT *point, double a, double b, double c, double d, double e, double f, double g, double h, double i, double xoff, double yoff, double zoff, const char *xdimname, const char *ydimname, const char *zdimname);
+
 #endif /* _PC_API_H */

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -469,4 +469,7 @@ PCPATCH *pc_patch_translate(const PCPATCH *patch, double tx, double ty, double t
 /** translate a point */
 void pc_point_translate(PCPOINT *point, double tx, double ty, double tz, const char *xdimname, const char *ydimname, const char *zdimname);
 
+/** apply an affine transformation to a patch */
+PCPATCH *pc_patch_affine(const PCPATCH *patch, double a, double b, double c, double d, double e, double f, double g, double h, double i, double xoff, double yoff, double zoff, const char *xdimname, const char *ydimname, const char *zdimname);
+
 #endif /* _PC_API_H */

--- a/lib/pc_api_internal.h
+++ b/lib/pc_api_internal.h
@@ -90,6 +90,7 @@ typedef struct
 /* */
 typedef double PCMAT33[9];
 typedef double PCVEC3[3];
+typedef double PCMAT43[12];
 
 
 /** What is the endianness of this system? */
@@ -299,7 +300,9 @@ void pc_bitmap_filter(PCBITMAP *map, PC_FILTERTYPE filter, int i, double d, doub
 */
 
 void pc_matrix_set_from_quaternion(PCMAT33 mat, double qw, double qx, double qy, double qz);
+void pc_matrix_set_affine(PCMAT43 mat, double a, double b, double c, double d, double e, double f, double g, double h, double i, double xoff, double yoff, double zoff);
 void pc_matrix_multiply_vector(PCVEC3 rotatedvec, const PCMAT33 mat, const PCVEC3 vec);
+void pc_matrix_transform_affine(PCVEC3 res, const PCMAT43 mat, const PCVEC3 vec);
 
 #endif /* _PC_API_INTERNAL_H */
 

--- a/lib/pc_matrix.c
+++ b/lib/pc_matrix.c
@@ -51,6 +51,29 @@ pc_matrix_set_from_quaternion(PCMAT33 mat, double qw, double qx, double qy, doub
     mat[8] = 1 - ( xx + yy );
 }
 
+void
+pc_matrix_set_affine(PCMAT43 mat,
+        double a, double b, double c,
+        double d, double e, double f,
+        double g, double h, double i,
+        double xoff, double yoff, double zoff)
+{
+    mat[0] = a;
+    mat[1] = b;
+    mat[2] = c;
+    mat[3] = xoff;
+
+    mat[4] = d;
+    mat[5] = e;
+    mat[6] = f;
+    mat[7] = yoff;
+
+    mat[8] = g;
+    mat[9] = h;
+    mat[10] = i;
+    mat[11] = zoff;
+}
+
 /**
 * Multiply mat by vec and store the resuting vector in res.
 */
@@ -60,4 +83,19 @@ pc_matrix_multiply_vector(PCVEC3 res, const PCMAT33 mat, const PCVEC3 vec)
     res[0] = mat[0] * vec[0] + mat[1] * vec[1] + mat[2] * vec[2];
     res[1] = mat[3] * vec[0] + mat[4] * vec[1] + mat[5] * vec[2];
     res[2] = mat[6] * vec[0] + mat[7] * vec[1] + mat[8] * vec[2];
+}
+
+/**
+* Apply an affine transformation to the vector vec and store the resulting
+* vector in res.
+*/
+void
+pc_matrix_transform_affine(PCVEC3 res, const PCMAT43 mat, const PCVEC3 vec)
+{
+    res[0] = mat[0] * vec[0] + mat[1] * vec[1]
+        + mat[2] * vec[2] + mat[3];
+    res[1] = mat[4] * vec[0] + mat[5] * vec[1]
+        + mat[6] * vec[2] + mat[7];
+    res[2] = mat[8] * vec[0] + mat[9] * vec[1]
+        + mat[10] * vec[2] + mat[11];
 }

--- a/lib/pc_point.c
+++ b/lib/pc_point.c
@@ -437,3 +437,39 @@ pc_point_translate(
     pc_point_set_double(point, ydim, y + ty);
     pc_point_set_double(point, zdim, z + tz);
 }
+
+/**
+* Apply an affine transformation to a point.
+*/
+void
+pc_point_affine(
+    PCPOINT *point,
+    double a, double b, double c,
+    double d, double e, double f,
+    double g, double h, double i,
+    double xoff, double yoff, double zoff,
+    const char *xdimname, const char *ydimname, const char *zdimname)
+{
+    const PCSCHEMA *schema;
+    const PCDIMENSION *xdim, *ydim, *zdim;
+    PCMAT43 amat;
+    PCVEC3 vec, rvec;
+
+    pc_matrix_set_affine(amat, a, b, c, d, e, f, g, h, i, xoff, yoff, zoff);
+
+    schema = point->schema;
+
+    xdim = pc_schema_get_dimension_by_name(schema, xdimname);
+    ydim = pc_schema_get_dimension_by_name(schema, ydimname);
+    zdim = pc_schema_get_dimension_by_name(schema, zdimname);
+
+    pc_point_get_double(point, xdim, &vec[0]);
+    pc_point_get_double(point, ydim, &vec[1]);
+    pc_point_get_double(point, zdim, &vec[2]);
+
+    pc_matrix_transform_affine(rvec, amat, vec);
+
+    pc_point_set_double(point, xdim, rvec[0]);
+    pc_point_set_double(point, ydim, rvec[1]);
+    pc_point_set_double(point, zdim, rvec[2]);
+}

--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -227,8 +227,8 @@ Datum pcpoint_rotate_quaternion(PG_FUNCTION_ARGS)
 
 /**
 * Translate a point
-* PC_RotateTranslate(point pcpoint, tx float8, ty float8, tz float8,
-*                    xdimname text, ydimname text, zdimname text) returns pcpoint
+* PC_Translate(point pcpoint, tx float8, ty float8, tz float8,
+*              xdimname text, ydimname text, zdimname text) returns pcpoint
 */
 PG_FUNCTION_INFO_V1(pcpoint_translate);
 Datum pcpoint_translate(PG_FUNCTION_ARGS)

--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -66,51 +66,6 @@ Datum pcpatch_rotate_quaternion(PG_FUNCTION_ARGS)
 }
 
 /**
-* Rotate a point based on a rotation quaternion
-* PC_RotateQuaternion(point pcpoint, qw float8, qx float8, qy float8, qz float8,
-*                     xdimname text, ydimname text, zdimname text) returns pcpoint
-*/
-PG_FUNCTION_INFO_V1(pcpoint_rotate_quaternion);
-Datum pcpoint_rotate_quaternion(PG_FUNCTION_ARGS)
-{
-    SERIALIZED_POINT *serpoint;
-    PCPOINT *point;
-    PCSCHEMA *schema;
-    float8 qw, qx, qy, qz;
-    char *xdimname, *ydimname, *zdimname;
-
-    if ( PG_ARGISNULL(0) )
-        PG_RETURN_NULL();   /* returns null if no input values */
-
-    serpoint = PG_GETARG_SERPOINT_P(0);
-    qw = PG_GETARG_FLOAT8(1);
-    qx = PG_GETARG_FLOAT8(2);
-    qy = PG_GETARG_FLOAT8(3);
-    qz = PG_GETARG_FLOAT8(4);
-    xdimname = text_to_cstring(PG_GETARG_TEXT_P(5));
-    ydimname = text_to_cstring(PG_GETARG_TEXT_P(6));
-    zdimname = text_to_cstring(PG_GETARG_TEXT_P(7));
-
-    schema = pc_schema_from_pcid(serpoint->pcid, fcinfo);
-
-    point = pc_point_deserialize(serpoint, schema);
-    if ( ! point )
-    {
-        elog(ERROR, "failed to deserialize point");
-        PG_RETURN_NULL();
-    }
-
-    pc_point_rotate_quaternion(
-        point, qw, qx, qy, qz, xdimname, ydimname, zdimname);
-
-    serpoint = pc_point_serialize(point);
-
-    pc_point_free(point);
-
-    PG_RETURN_POINTER(serpoint);
-}
-
-/**
 * Translate a patch
 * PC_Translate(patch pcpatch, tx float8, ty float8, tz float8,
 *              xdimname text, ydimname text, zdimname text) returns pcpatch
@@ -158,6 +113,116 @@ Datum pcpatch_translate(PG_FUNCTION_ARGS)
     pc_patch_free(patch_out);
 
     PG_RETURN_POINTER(serpatch);
+}
+
+/**
+* Apply an affine transformation to a patch
+* PC_Affine(patch pcpatch,
+*           a float8, b float8, c float8,
+*           d float8, e float8, f float8,
+*           g float8, h float8, i float8,
+*           xoff float8, yoff float8, zoff float8,
+*           xdimname text, ydimname text, zdimname text) returns pcpatch
+*/
+PG_FUNCTION_INFO_V1(pcpatch_affine);
+Datum pcpatch_affine(PG_FUNCTION_ARGS)
+{
+    SERIALIZED_PATCH *serpatch;
+    PCPATCH *patch_in, *patch_out;
+    PCSCHEMA *schema;
+    float8 a, b, c, d, e, f, g, h, i;
+    float8 xoff, yoff, zoff;
+    char *xdimname, *ydimname, *zdimname;
+
+    if ( PG_ARGISNULL(0) )
+        PG_RETURN_NULL();   /* returns null if no input values */
+
+    serpatch = PG_GETARG_SERPATCH_P(0);
+    a = PG_GETARG_FLOAT8(1);
+    b = PG_GETARG_FLOAT8(2);
+    c = PG_GETARG_FLOAT8(3);
+    d = PG_GETARG_FLOAT8(4);
+    e = PG_GETARG_FLOAT8(5);
+    f = PG_GETARG_FLOAT8(6);
+    g = PG_GETARG_FLOAT8(7);
+    h = PG_GETARG_FLOAT8(8);
+    i = PG_GETARG_FLOAT8(9);
+    xoff = PG_GETARG_FLOAT8(10);
+    yoff = PG_GETARG_FLOAT8(11);
+    zoff = PG_GETARG_FLOAT8(12);
+    xdimname = text_to_cstring(PG_GETARG_TEXT_P(13));
+    ydimname = text_to_cstring(PG_GETARG_TEXT_P(14));
+    zdimname = text_to_cstring(PG_GETARG_TEXT_P(15));
+
+    schema = pc_schema_from_pcid(serpatch->pcid, fcinfo);
+
+    patch_in = pc_patch_deserialize(serpatch, schema);
+    if ( ! patch_in )
+    {
+        elog(ERROR, "failed to deserialize patch");
+        PG_RETURN_NULL();
+    }
+
+    patch_out = pc_patch_affine(patch_in,
+        a, b, c, d, e, f, g, h, i, xoff, yoff, zoff,
+        xdimname, ydimname, zdimname);
+    if ( ! patch_out )
+    {
+        elog(ERROR, "failed to rotate patch");
+        PG_RETURN_NULL();
+    }
+
+    serpatch = pc_patch_serialize(patch_out, NULL);
+
+    pc_patch_free(patch_in);
+    pc_patch_free(patch_out);
+
+    PG_RETURN_POINTER(serpatch);
+}
+
+/**
+* Rotate a point based on a rotation quaternion
+* PC_RotateQuaternion(point pcpoint, qw float8, qx float8, qy float8, qz float8,
+*                     xdimname text, ydimname text, zdimname text) returns pcpoint
+*/
+PG_FUNCTION_INFO_V1(pcpoint_rotate_quaternion);
+Datum pcpoint_rotate_quaternion(PG_FUNCTION_ARGS)
+{
+    SERIALIZED_POINT *serpoint;
+    PCPOINT *point;
+    PCSCHEMA *schema;
+    float8 qw, qx, qy, qz;
+    char *xdimname, *ydimname, *zdimname;
+
+    if ( PG_ARGISNULL(0) )
+        PG_RETURN_NULL();   /* returns null if no input values */
+
+    serpoint = PG_GETARG_SERPOINT_P(0);
+    qw = PG_GETARG_FLOAT8(1);
+    qx = PG_GETARG_FLOAT8(2);
+    qy = PG_GETARG_FLOAT8(3);
+    qz = PG_GETARG_FLOAT8(4);
+    xdimname = text_to_cstring(PG_GETARG_TEXT_P(5));
+    ydimname = text_to_cstring(PG_GETARG_TEXT_P(6));
+    zdimname = text_to_cstring(PG_GETARG_TEXT_P(7));
+
+    schema = pc_schema_from_pcid(serpoint->pcid, fcinfo);
+
+    point = pc_point_deserialize(serpoint, schema);
+    if ( ! point )
+    {
+        elog(ERROR, "failed to deserialize point");
+        PG_RETURN_NULL();
+    }
+
+    pc_point_rotate_quaternion(
+        point, qw, qx, qy, qz, xdimname, ydimname, zdimname);
+
+    serpoint = pc_point_serialize(point);
+
+    pc_point_free(point);
+
+    PG_RETURN_POINTER(serpoint);
 }
 
 /**

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -346,6 +346,10 @@ CREATE OR REPLACE FUNCTION PC_Affine(p pcpatch, a float8, b float8, c float8, d 
     RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_affine'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Affine(p pcpoint, a float8, b float8, c float8, d float8, e float8, f float8, g float8, h float8, i float8, xoff float8, yoff float8, zoff float8, xdimname text, ydimname text, zdimname text)
+    RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_affine'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -342,6 +342,10 @@ CREATE OR REPLACE FUNCTION PC_Translate(p pcpoint, tx float8, ty float8, tz floa
     RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_translate'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Affine(p pcpatch, a float8, b float8, c float8, d float8, e float8, f float8, g float8, h float8, i float8, xoff float8, yoff float8, zoff float8, xdimname text, ydimname text, zdimname text)
+    RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_affine'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
This PR adds `PC_Affine(pcpatch)` and `PC_Affine(pcpoint)` for applying affine transformations to patches and points, respectively.