### PR TITLE
[WIP] Add zmin and zmax to PCBOUNDS

### DIFF
--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -150,6 +150,8 @@ typedef struct
 	double xmax;
 	double ymin;
 	double ymax;
+	double zmin;
+	double zmax;
 } PCBOUNDS;
 
 /* Used for generic patch statistics */

--- a/lib/pc_patch_dimensional.c
+++ b/lib/pc_patch_dimensional.c
@@ -179,7 +179,7 @@ pc_patch_dimensional_free(PCPATCH_DIMENSIONAL *pdl)
 int
 pc_patch_dimensional_compute_extent(PCPATCH_DIMENSIONAL *pdl)
 {
-	double xmin, xmax, ymin, ymax, xavg, yavg;
+	double xmin, xmax, ymin, ymax, zmin, zmax, xavg, yavg, zavg;
 	int rv;
 	PCBYTES *pcb;
 
@@ -203,6 +203,18 @@ pc_patch_dimensional_compute_extent(PCPATCH_DIMENSIONAL *pdl)
 	ymax = pc_value_scale_offset(ymax, pdl->schema->dims[pdl->schema->y_position]);
 	pdl->bounds.ymin = ymin;
 	pdl->bounds.ymax = ymax;
+
+	if ( pdl->schema->z_position > -1 )
+	{
+		/* Get z extremes */
+		pcb = &(pdl->bytes[pdl->schema->z_position]);
+		rv = pc_bytes_minmax(pcb, &zmin, &zmax, &zavg);
+		if ( PC_FAILURE == rv ) return PC_FAILURE;
+		ymin = pc_value_scale_offset(zmin, pdl->schema->dims[pdl->schema->z_position]);
+		ymax = pc_value_scale_offset(zmax, pdl->schema->dims[pdl->schema->z_position]);
+		pdl->bounds.zmin = zmin;
+		pdl->bounds.zmax = zmax;
+	}
 
 	return PC_SUCCESS;
 }

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -402,6 +402,9 @@ pc_patch_ght_compute_extent(PCPATCH_GHT *patch)
 	patch->bounds.ymin = area.y.min;
 	patch->bounds.ymax = area.y.max;
 
+	// GHT does not have z.min and z.max, so a 2d bounds
+	// is used although the patch may be 3d
+
 	// ght_tree_free(tree);
 
 	return PC_SUCCESS;

--- a/lib/pc_patch_uncompressed.c
+++ b/lib/pc_patch_uncompressed.c
@@ -191,7 +191,7 @@ pc_patch_uncompressed_compute_extent(PCPATCH_UNCOMPRESSED *patch)
 	int i;
 	PCPOINT *pt = pc_point_from_data(patch->schema, patch->data);
 	PCBOUNDS b;
-	double x, y;
+	double x, y, z;
 
 	/* Calculate bounds */
 	pc_bounds_init(&b);
@@ -199,12 +199,21 @@ pc_patch_uncompressed_compute_extent(PCPATCH_UNCOMPRESSED *patch)
 	{
 		/* Just push the data buffer forward by one point at a time */
 		pt->data = patch->data + i * patch->schema->size;
+
 		x = pc_point_get_x(pt);
-		y = pc_point_get_y(pt);
 		if ( b.xmin > x ) b.xmin = x;
-		if ( b.ymin > y ) b.ymin = y;
 		if ( b.xmax < x ) b.xmax = x;
+
+		y = pc_point_get_y(pt);
+		if ( b.ymin > y ) b.ymin = y;
 		if ( b.ymax < y ) b.ymax = y;
+
+		if ( pt->schema->z_position > -1 )
+		{
+			z = pc_point_get_z(pt);
+			if ( b.zmin > z ) b.zmin = z;
+			if ( b.zmax < z ) b.zmax = z;
+		}
 	}
 
 	patch->bounds = b;

--- a/lib/pc_util.c
+++ b/lib/pc_util.c
@@ -238,21 +238,41 @@ uncompressed_bytes_flip_endian(const uint8_t *bytebuf, const PCSCHEMA *schema, u
 int
 pc_bounds_intersects(const PCBOUNDS *b1, const PCBOUNDS *b2)
 {
-	if (	b1->xmin > b2->xmax ||
-		b1->xmax < b2->xmin ||
-		b1->ymin > b2->ymax ||
-		b1->ymax < b2->ymin )
+	if ( b1->xmin > b2->xmax ||
+		 b1->xmax < b2->xmin ||
+		 b1->ymin > b2->ymax ||
+		 b1->ymax < b2->ymin )
 	{
 		return PC_FALSE;
 	}
+
+	if ( b1->zmin == DBL_MAX && b2->zmin == DBL_MAX )
+	{
+		// b1 and b2 are both 2d, so we are done
+		return PC_TRUE;
+	}
+
+	if ( b1->zmin == DBL_MAX ||
+		 b2->zmin == DBL_MAX )
+	{
+		// b1 is 2d and b2 is 3d, or vice-versa
+		return PC_FALSE;
+	}
+
+	if ( b1->zmin > b2->zmax ||
+		 b1->zmax < b2->zmin )
+	{
+		return PC_FALSE;
+	}
+
 	return PC_TRUE;
 }
 
 void
 pc_bounds_init(PCBOUNDS *b)
 {
-	b->xmin = b->ymin = DBL_MAX;
-	b->xmax = b->ymax = -1*DBL_MAX;
+	b->xmin = b->ymin = b->zmin = DBL_MAX;
+	b->xmax = b->ymax = b->zmax = -1*DBL_MAX;
 }
 
 void pc_bounds_merge(PCBOUNDS *b1, const PCBOUNDS *b2)
@@ -261,5 +281,10 @@ void pc_bounds_merge(PCBOUNDS *b1, const PCBOUNDS *b2)
 	if ( b2->ymin < b1->ymin ) b1->ymin = b2->ymin;
 	if ( b2->xmax > b1->xmax ) b1->xmax = b2->xmax;
 	if ( b2->ymax > b1->ymax ) b1->ymax = b2->ymax;
+	if ( b1->zmin != DBL_MAX && b2->zmin != DBL_MAX )
+	{
+		if ( b2->zmin < b1->zmin ) b1->zmin = b2->zmin;
+		if ( b2->zmax > b1->zmax ) b1->zmax = b2->zmax;
+	}
 }
 

--- a/pgsql/expected/pointcloud-laz.out
+++ b/pgsql/expected/pointcloud-laz.out
@@ -96,7 +96,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_laz;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_laz;
  sum 
 -----
- 487
+ 551
 (1 row)
 
 SELECT Sum(PC_PatchMax(pa,'x')) FROM pa_test_laz;
@@ -192,7 +192,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_laz;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_laz;
  sum  
 ------
- 1499
+ 1579
 (1 row)
 
 SELECT Max(PC_PatchMax(pa,'x')) FROM pa_test_laz;

--- a/pgsql/expected/pointcloud.out
+++ b/pgsql/expected/pointcloud.out
@@ -343,7 +343,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_dim;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_dim;
  sum 
 -----
- 684
+ 748
 (1 row)
 
 SELECT Sum(PC_PatchMax(pa,'x')) FROM pa_test_dim;
@@ -379,7 +379,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_dim;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_dim;
  sum  
 ------
- 8733
+ 8813
 (1 row)
 
 SELECT Max(PC_PatchMax(pa,'x')) FROM pa_test_dim;


### PR DESCRIPTION
This is required if we want to take z into account when checking that patch bounds intersect.

At this point I am just creating this PR for discussion. @mbredif does that make sense to you?