### PR TITLE
remove xy dimension check

### DIFF
--- a/lib/cunit/cu_pc_schema.c
+++ b/lib/cunit/cu_pc_schema.c
@@ -154,12 +154,17 @@ test_dimension_byteoffsets()
 }
 
 static void
-test_schema_invalid_xy()
+test_schema_xdim_only()
 {
 	// See https://github.com/pgpointcloud/pointcloud/issues/28
 	char *xmlstr = "<pc:PointCloudSchema xmlns:pc='x'><pc:dimension>1</pc:dimension></pc:PointCloudSchema>";
 	PCSCHEMA *myschema = pc_schema_from_xml(xmlstr);
-	CU_ASSERT_PTR_NULL(myschema);
+	CU_ASSERT_PTR_NOT_NULL(myschema);
+	CU_ASSERT_PTR_NULL(myschema->xdim);
+	CU_ASSERT_PTR_NULL(myschema->ydim);
+	CU_ASSERT_PTR_NULL(myschema->zdim);
+	CU_ASSERT_PTR_NULL(myschema->mdim);
+	pc_schema_free(myschema);
 }
 
 static void
@@ -315,7 +320,7 @@ CU_TestInfo schema_tests[] = {
 	PC_TEST(test_dimension_get),
 	PC_TEST(test_dimension_byteoffsets),
 	PC_TEST(test_schema_compression),
-	PC_TEST(test_schema_invalid_xy),
+	PC_TEST(test_schema_xdim_only),
 	PC_TEST(test_schema_missing_dimension),
 	PC_TEST(test_schema_empty),
 	PC_TEST(test_schema_clone),

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -132,8 +132,8 @@ pc_patch_ght_from_uncompressed(const PCPATCH_UNCOMPRESSED *pa)
 	pt.schema = pa->schema;
 	pt.readonly = PC_TRUE;
 
-	xdim = pa->schema->dims[pa->schema->x_position];
-	ydim = pa->schema->dims[pa->schema->y_position];
+	xdim = pa->schema->xdim;
+	ydim = pa->schema->ydim;
 
 	schema = ght_schema_from_pc_schema(pa->schema);
 	if ( ght_tree_new(schema, &tree) != GHT_OK ) {
@@ -162,11 +162,11 @@ pc_patch_ght_from_uncompressed(const PCPATCH_UNCOMPRESSED *pa)
 				GhtAttributePtr attr;
 				double val;
 
+				dim = pc_schema_get_dimension(pa->schema, j);
 				/* Don't add X or Y as attributes, they are already embodied in the hash */
-				if ( j == pa->schema->x_position || j == pa->schema->y_position )
+				if ( dim == xdim || dim == ydim )
 					continue;
 
-				dim = pc_schema_get_dimension(pa->schema, j);
 				pc_point_get_double(&pt, dim, &val);
 
 				ght_schema_get_dimension_by_index(schema, j, &ghtdim);

--- a/lib/pc_schema.c
+++ b/lib/pc_schema.c
@@ -581,18 +581,6 @@ pc_schema_is_valid(const PCSCHEMA *s)
 {
 	int i;
 
-	if ( ! s->xdim )
-	{
-		pcwarn("schema does not include an X coordinate");
-		return PC_FALSE;
-	}
-
-	if ( ! s->ydim )
-	{
-		pcwarn("schema does not include a Y coordinate");
-		return PC_FALSE;
-	}
-
 	if ( ! s->ndims )
 	{
 		pcwarn("schema has no dimensions");


### PR DESCRIPTION
This PR removes the validity condition that a schema should have a xdim and a ydim.
The intended behavior is that these are only required when converting to postgis objects. If xdim or ydim is NULL, then those conversions should return NULL.
This PR is motivated by the LI3DS project where the pcpatches are used not only to store lidar point clouds (which generally include a x/y) but also other elements which may not have a clear x/y dimension (such as transformation parameters).