### PR TITLE
Add PC_[Un]distortPolyRadial5 and PC_[Un]distortPolyRadial7

### DIFF
--- a/lib/li_api.h
+++ b/lib/li_api.h
@@ -70,6 +70,8 @@ LIBOX4 *li_box4d_affine(LIBOX4 ibox, double a, double b, double c, double d, dou
 
 LIBOX4 *li_box4d_rotate_quaternion(LIBOX4 ibox, double qw, double qx, double qy, double qz);
 
+LIBOX4 *li_box4d_distort(LIBOX4 ibox, double pps0, double pps1, double c0, double c1, double c2);
+
 LIBOX4 *li_box4d_undistort(LIBOX4 ibox, double pps0, double pps1, double c0, double c1, double c2);
 
 /** convert a box to a frustum (lossless) */

--- a/lib/li_api.h
+++ b/lib/li_api.h
@@ -70,6 +70,8 @@ LIBOX4 *li_box4d_affine(LIBOX4 ibox, double a, double b, double c, double d, dou
 
 LIBOX4 *li_box4d_rotate_quaternion(LIBOX4 ibox, double qw, double qx, double qy, double qz);
 
+LIBOX4 *li_box4d_undistort(LIBOX4 ibox, double pps0, double pps1, double c0, double c1, double c2);
+
 /** convert a box to a frustum (lossless) */
 int li_frustum_from_box(LIFRUSTUM *res, const LIBOX3 b);
 

--- a/lib/li_api_internal.h
+++ b/lib/li_api_internal.h
@@ -26,6 +26,7 @@ double li_matrix_44_determinant(const LIMAT44 m);
 void li_matrix_44_adjugate(LIMAT44 res, const LIMAT44 m, double *determinant);
 int li_matrix_44_inverse(LIMAT44 res, const LIMAT44 m);
 void li_distortion_set(LIDISTORSION*, double, double, double, double, double);
+int li_box_transform_distorsion(LIBOX3, const LIDISTORSION*, const LIBOX3);
 int li_box_transform_undistorsion(LIBOX3, const LIDISTORSION*, const LIBOX3);
 
 void li_matrix_44_warn(const char *func, int line, const char *name, const LIMAT44 m);

--- a/lib/li_api_internal.h
+++ b/lib/li_api_internal.h
@@ -25,6 +25,8 @@ void li_matrix_44_multiply_vector_4(LIVEC4 res, const LIMAT44 mat, const LIVEC4 
 double li_matrix_44_determinant(const LIMAT44 m);
 void li_matrix_44_adjugate(LIMAT44 res, const LIMAT44 m, double *determinant);
 int li_matrix_44_inverse(LIMAT44 res, const LIMAT44 m);
+void li_distortion_set(LIDISTORSION*, double, double, double, double, double);
+int li_box_transform_undistorsion(LIBOX3, const LIDISTORSION*, const LIBOX3);
 
 void li_matrix_44_warn(const char *func, int line, const char *name, const LIMAT44 m);
 void li_vector_3_warn(const char *func, int line, const char *name, const LIVEC4 v);

--- a/lib/li_box4d.c
+++ b/lib/li_box4d.c
@@ -121,3 +121,40 @@ li_box4d_undistort(
 
 	return obox;
 }
+
+
+/**
+* Distort a box4d.
+*/
+LIBOX4 *
+li_box4d_distort(
+	LIBOX4 ibox,
+	double pps0, double pps1, double c0, double c1, double c2)
+{
+	int d;
+	LIBOX3 res;
+	LIDISTORSION dist;
+	LIBOX4 *obox;
+	const LIBOX3 box = {
+		{ibox[0][0], ibox[0][1], ibox[0][2]},
+		{ibox[1][0], ibox[1][1], ibox[1][2]}};
+
+	li_distortion_set(&dist, pps0, pps1, c0, c1, c2);
+
+	if ( li_box_transform_distorsion(res, &dist, box) == PC_FAILURE )
+		return NULL;
+
+	obox = pcalloc(sizeof(LIBOX4));
+
+	// m values are unchanged
+	(*obox)[0][3] = ibox[0][3];
+	(*obox)[1][3] = ibox[1][3];
+
+	for ( d = 0; d < 3; d++)
+	{
+		(*obox)[0][d] = res[0][d];
+		(*obox)[1][d] = res[1][d];
+	}
+
+	return obox;
+}

--- a/lib/li_box4d.c
+++ b/lib/li_box4d.c
@@ -84,3 +84,40 @@ li_box4d_affine(
 	li_matrix_43_set(amat, a, b, c, xoff, d, e, f, yoff, g, h, i, zoff);
 	return li_box4d_transform(ibox, amat, li_matrix_43_transform_affine);
 }
+
+
+/**
+* Undistort a box4d.
+*/
+LIBOX4 *
+li_box4d_undistort(
+	LIBOX4 ibox,
+	double pps0, double pps1, double c0, double c1, double c2)
+{
+	int d;
+	LIBOX3 res;
+	LIDISTORSION dist;
+	LIBOX4 *obox;
+	const LIBOX3 box = {
+		{ibox[0][0], ibox[0][1], ibox[0][2]},
+		{ibox[1][0], ibox[1][1], ibox[1][2]}};
+
+	li_distortion_set(&dist, pps0, pps1, c0, c1, c2);
+
+	if ( li_box_transform_undistorsion(res, &dist, box) == PC_FAILURE )
+		return NULL;
+
+	obox = pcalloc(sizeof(LIBOX4));
+
+	// m values are unchanged
+	(*obox)[0][3] = ibox[0][3];
+	(*obox)[1][3] = ibox[1][3];
+
+	for ( d = 0; d < 3; d++)
+	{
+		(*obox)[0][d] = res[0][d];
+		(*obox)[1][d] = res[1][d];
+	}
+
+	return obox;
+}

--- a/lib/li_box4d.c
+++ b/lib/li_box4d.c
@@ -6,6 +6,8 @@
 #include "pc_api_internal.h"
 #include "li_api_internal.h"
 
+#include <math.h>
+
 
 typedef void (*transform_fn_t)(LIVEC3, const double *, const LIVEC3);
 
@@ -35,15 +37,16 @@ li_box4d_transform(LIBOX4 ibox, void *mat, transform_fn_t transform)
 
 		transform(rvec, mat, vec);
 
-		for ( d = 0; d < 3; d++ )
-		{
-			if ( idx == 0 )
+		if (idx == 0 )
+			for ( d = 0; d < 3; d++ )
 				(*obox)[0][d] = (*obox)[1][d] = rvec[d];
-			else if ( rvec[d] < (*obox)[0][d] )
-				(*obox)[0][d] = rvec[d];
-			else if ( rvec[d] > (*obox)[1][d] )
-				(*obox)[1][d] = rvec[d];
-		}
+		else
+			for ( d = 0; d < 3; d++ )
+			{
+				(*obox)[0][d] = fmin((*obox)[0][d], rvec[d]);
+				(*obox)[1][d] = fmax((*obox)[1][d], rvec[d]);
+			}
+
 	}
 
 	return obox;

--- a/lib/li_matrix.c
+++ b/lib/li_matrix.c
@@ -660,11 +660,20 @@ li_frustum_spherical_from_cartesian(LIFRUSTUM *res, const LIFRUSTUM *f)
 }
 
 
+void
+li_distortion_set(LIDISTORSION* dist, double pps0, double pps1, double c0, double c1, double c2)
+{
+	dist->pps[0] = pps0;
+	dist->pps[1] = pps1;
+	dist->c[0] = c0;
+	dist->c[1] = c1;
+	dist->c[2] = c2;
+}
+
 /**
 * Distorsion polynom : r3,r5,r7
 * https://github.com/IGNF/libOri/blob/master/src/DistortionPolynom.cpp
 */
-
 int
 li_vector_3_distorsion(LIVEC3 res, const LIDISTORSION *d, const LIVEC3 vec)
 {

--- a/lib/li_matrix.c
+++ b/lib/li_matrix.c
@@ -663,11 +663,14 @@ li_frustum_spherical_from_cartesian(LIFRUSTUM *res, const LIFRUSTUM *f)
 void
 li_distortion_set(LIDISTORSION* dist, double pps0, double pps1, double c0, double c1, double c2)
 {
+	// FIXME: compte r2max when not provided
+	// see https://github.com/IGNF/libOri/blob/e5b0234/src/DistortionPolynom.cpp#L11-L84
 	dist->pps[0] = pps0;
 	dist->pps[1] = pps1;
 	dist->c[0] = c0;
 	dist->c[1] = c1;
 	dist->c[2] = c2;
+	dist->r2max = 0;
 }
 
 /**
@@ -680,7 +683,7 @@ li_vector_3_distorsion(LIVEC3 res, const LIDISTORSION *d, const LIVEC3 vec)
 	double v[] = { res[0]-d->pps[0], res[0]-d->pps[1] };
 	double r2 = v[0]*v[0]+v[1]*v[1];
 	double dr;
-	if(r2>d->r2max)
+	if ( d->r2max > 0 && r2 > d->r2max )
 		return PC_FAILURE;
 
 	dr = r2*(d->c[0] + r2*(d->c[1] + r2*d->c[2]));
@@ -733,7 +736,7 @@ li_box_transform_distorsion(LIBOX3 res, const LIDISTORSION *d, const LIBOX3 b)
 	}
 	for( i = 0; i < 4; ++i )
 	{
-		if(r2c[i] > d->r2max)
+		if ( d->r2max > 0 && r2c[i] > d->r2max )
 			return PC_FAILURE;
 
 		Pe[i] = fmax(Pc[i],Pc[(i+1)%4]);
@@ -796,7 +799,7 @@ li_vector_3_undistorsion(LIVEC3 res, const LIDISTORSION *d, const LIVEC3 vec)
 		double t2 = t *t;
 		double R_, R  = -1+t+t*t2*(c3+t2*(c5+t2*c7));
 
-		if(R*R*r2<LIUNDISTORSION_ERR2MAX && t2*r2<d->r2max)
+		if ( R*R*r2<LIUNDISTORSION_ERR2MAX && (d->r2max <= 0 || t2*r2 < d->r2max))
 		{
 			res[0] = d->pps[0] + t * v[0];
 			res[1] = d->pps[1] + t * v[1];

--- a/pgsql/li_editor.c
+++ b/pgsql/li_editor.c
@@ -22,6 +22,7 @@ Datum lipoint_translate(PG_FUNCTION_ARGS);
 Datum lipoint_affine(PG_FUNCTION_ARGS);
 Datum lipoint_projective(PG_FUNCTION_ARGS);
 Datum libox4d_undistort_poly_radial(PG_FUNCTION_ARGS);
+Datum libox4d_distort_poly_radial(PG_FUNCTION_ARGS);
 
 static float8* li_getarg_float8_array(FunctionCallInfoData *fcinfo, int pos, int num_elts)
 {
@@ -606,6 +607,61 @@ Datum libox4d_undistort_poly_radial(PG_FUNCTION_ARGS)
 	if ( ! obox )
 	{
 		elog(ERROR, "internal error in libox4d_undistort_poly_radial");
+		PG_RETURN_NULL();
+	}
+
+	PG_RETURN_POINTER(obox);
+}
+
+/**
+* Distort a box using distortion polynom.
+* PC_DistortPolyRadial5(box libox4d, pps float8[2], c float8[2]) returns libox4d
+* PC_DistortPolyRadial7(box libox4d, pps float8[2], c float8[3]) returns libox4d
+*/
+PG_FUNCTION_INFO_V1(libox4d_distort_poly_radial);
+Datum libox4d_distort_poly_radial(PG_FUNCTION_ARGS)
+{
+	int c_len;
+	int radial_type;
+	LIBOX4 *ibox, *obox;
+	float8 *pps, *c;
+	float8 c0, c1, c2;
+
+	if ( PG_ARGISNULL(0) )
+		PG_RETURN_NULL();	/* returns null if no input values */
+
+	radial_type = PG_GETARG_INT32(3);
+	switch ( radial_type )
+	{
+		case 5:
+			c_len = 2;
+			break;
+		case 7:
+			c_len = 3;
+			break;
+		default:
+			elog(ERROR, "radial type must be 3, 5 or 7");
+			PG_RETURN_NULL();
+	}
+
+	ibox = (LIBOX4 *) PG_GETARG_POINTER(0);
+
+	pps = li_getarg_float8_array(fcinfo, 1, 2);
+	if ( ! pps )
+		PG_RETURN_NULL();
+
+	c = li_getarg_float8_array(fcinfo, 2, c_len);
+	if ( ! c )
+		PG_RETURN_NULL();
+
+	c0 = c[0];
+	c1 = c[1];
+	c2 = c_len == 3 ? c[2] : 0;
+
+	obox = li_box4d_distort(*ibox, pps[0], pps[1], c0, c1, c2);
+	if ( ! obox )
+	{
+		elog(ERROR, "internal error in libox4d_distort_poly_radial");
 		PG_RETURN_NULL();
 	}
 

--- a/pgsql/li_editor.c
+++ b/pgsql/li_editor.c
@@ -21,6 +21,7 @@ Datum lipoint_rotate_quaternion(PG_FUNCTION_ARGS);
 Datum lipoint_translate(PG_FUNCTION_ARGS);
 Datum lipoint_affine(PG_FUNCTION_ARGS);
 Datum lipoint_projective(PG_FUNCTION_ARGS);
+Datum libox4d_undistort_poly_radial(PG_FUNCTION_ARGS);
 
 static float8* li_getarg_float8_array(FunctionCallInfoData *fcinfo, int pos, int num_elts)
 {
@@ -551,6 +552,61 @@ Datum libox4d_affine_quat(PG_FUNCTION_ARGS)
 	{
 		(*obox)[0][d] += vec[d];
 		(*obox)[1][d] += vec[d];
+	}
+
+	PG_RETURN_POINTER(obox);
+}
+
+/**
+* Undistort a box using distortion polynom.
+* PC_UndistortPolyRadial5(box libox4d, pps float8[2], c float8[2]) returns libox4d
+* PC_UndistortPolyRadial7(box libox4d, pps float8[2], c float8[3]) returns libox4d
+*/
+PG_FUNCTION_INFO_V1(libox4d_undistort_poly_radial);
+Datum libox4d_undistort_poly_radial(PG_FUNCTION_ARGS)
+{
+	int c_len;
+	int radial_type;
+	LIBOX4 *ibox, *obox;
+	float8 *pps, *c;
+	float8 c0, c1, c2;
+
+	if ( PG_ARGISNULL(0) )
+		PG_RETURN_NULL();	/* returns null if no input values */
+
+	radial_type = PG_GETARG_INT32(3);
+	switch ( radial_type )
+	{
+		case 5:
+			c_len = 2;
+			break;
+		case 7:
+			c_len = 3;
+			break;
+		default:
+			elog(ERROR, "radial type must be 3, 5 or 7");
+			PG_RETURN_NULL();
+	}
+
+	ibox = (LIBOX4 *) PG_GETARG_POINTER(0);
+
+	pps = li_getarg_float8_array(fcinfo, 1, 2);
+	if ( ! pps )
+		PG_RETURN_NULL();
+
+	c = li_getarg_float8_array(fcinfo, 2, c_len);
+	if ( ! c )
+		PG_RETURN_NULL();
+
+	c0 = c[0];
+	c1 = c[1];
+	c2 = c_len == 3 ? c[2] : 0;
+
+	obox = li_box4d_undistort(*ibox, pps[0], pps[1], c0, c1, c2);
+	if ( ! obox )
+	{
+		elog(ERROR, "internal error in libox4d_undistort_poly_radial");
+		PG_RETURN_NULL();
 	}
 
 	PG_RETURN_POINTER(obox);

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -536,3 +536,11 @@ CREATE OR REPLACE FUNCTION PC_Affine(box libox4d, mat43 float8[12])
 CREATE OR REPLACE FUNCTION PC_Affine(box libox4d, quat float8[4], vec float8[3])
 	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_affine_quat'
 	LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION PC_UndistortPolyRadial5(box libox4d, pps float8[2], c float8[2], type integer default 5)
+	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_undistort_poly_radial'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION PC_UndistortPolyRadial7(box libox4d, pps float8[2], c float8[3], type integer default 7)
+	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_undistort_poly_radial'
+	LANGUAGE 'c' IMMUTABLE STRICT;

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -537,6 +537,14 @@ CREATE OR REPLACE FUNCTION PC_Affine(box libox4d, quat float8[4], vec float8[3])
 	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_affine_quat'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_DistortPolyRadial5(box libox4d, pps float8[2], c float8[2], type integer default 5)
+	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_distort_poly_radial'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION PC_DistortPolyRadial7(box libox4d, pps float8[2], c float8[3], type integer default 7)
+	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_distort_poly_radial'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION PC_UndistortPolyRadial5(box libox4d, pps float8[2], c float8[2], type integer default 5)
 	RETURNS libox4d AS 'MODULE_PATHNAME', 'libox4d_undistort_poly_radial'
 	LANGUAGE 'c' IMMUTABLE STRICT;


### PR DESCRIPTION
@mbredif can you take a look at this?

The functions don't work for me. I always get "ERROR:  internal error in libox4d_undistort_poly_radial". This is because the `li_vector_3_undistorsion` function fails to perform the undistortion operation in 50 iterations.

```sql
# select pc_undistortpolyradial5('BOX4D(-1 -1 1 10,1 1 -1 20)'::LIBOX4D, ARRAY[2047.0,2048.0], ARRAY[0.00000000004106804505990795,-0.0000000000000000009287940817219032]);                              
WARNING:  li_box_transform_undistorsion: current implementation is not conservative (bbox of 8points)... 
ERROR:  internal error in libox4d_undistort_poly_radial
```

@mbredif, can you please have a look? Is this related to the parameters I use?